### PR TITLE
fix KAFKA_HOME symlink to unpacked tgz dir

### DIFF
--- a/phoebus-alarm-server/Dockerfile
+++ b/phoebus-alarm-server/Dockerfile
@@ -53,7 +53,7 @@ RUN yum install -y wget ${JAVA_BASE}-${JAVA_VERSION} readline libsdc++ && \
     wget https://downloads.apache.org/kafka/2.8.1/kafka_2.13-2.8.1.tgz -O /tmp/kafka_2.13-2.8.1.tgz && \
     tar xvfz /tmp/kafka_2.13-2.8.1.tgz -C /opt && \
     rm /tmp/kafka_2.13-2.8.1.tgz && \
-    ln -s /opt/kafka_2.13-2.8.1.tgz ${KAFKA_HOME} && \
+    ln -s /opt/kafka_2.13-2.8.1 ${KAFKA_HOME} && \
     rm -r /tmp/* 
 
 COPY --from=build /opt/phoebus-build /opt/phoebus


### PR DESCRIPTION
The symlink for `${KAFKA_HOME}` should be to the unpacked directory, not the `.tgz` file which is removed in the previous line.

Currently the container shows a broken link
```
[root@phoebus-alarm-server-b7b8cdd75-8dhjz cli]# ll /opt
total 0
lrwxrwxrwx 1 root root  25 Feb  7 18:16 kafka -> /opt/kafka_2.13-2.8.1.tgz
drwxr-xr-x 7 root root 105 Sep 14  2021 kafka_2.13-2.8.1
drwxr-xr-x 1 root root  31 Feb  7 18:13 nalms
drwxr-xr-x 1 root root  49 Feb  7 18:16 phoebus
```
Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>