### PR TITLE
Use Elasticsearch 7

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,5 +1,5 @@
 # Use the elasticsearch image (centos7)
-FROM docker.elastic.co/elasticsearch/elasticsearch:6.8.22@sha256:abb31b525b19f5b0e47c71a8db54dbf3860c58c7e15a572d2919f6bad53e947e
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.17.5@sha256:76344d5f89b13147743db0487eb76b03a7f9f0cd55abe8ab887069711f2ee27d
 
 COPY scripts/init_es.sh /opt/nalms/
 COPY scripts/create_alarm_template.sh /opt/nalms/

--- a/elasticsearch/scripts/create_alarm_template.sh
+++ b/elasticsearch/scripts/create_alarm_template.sh
@@ -33,7 +33,7 @@ curl -X PUT http://${ES_HOST}:${ES_PORT}/_ingest/pipeline/add_created_date -H 'C
 # "alarm", ""alarm_cmd", "alarm_config"
 
 # Create the elastic template with the correct mapping for alarm state messages.
-curl -XPUT http://${ES_HOST}:${ES_PORT}/_template/alarms_state_template -H 'Content-Type: application/json' -d'
+curl -XPUT http://${ES_HOST}:${ES_PORT}/_template/alarms_state_template?include_type_name=true -H 'Content-Type: application/json' -d'
 {
   "index_patterns":["*_alarms_state*"],
   "settings": {
@@ -97,7 +97,7 @@ curl -XPUT http://${ES_HOST}:${ES_PORT}/_template/alarms_state_template -H 'Cont
 '
 
 # Create the elastic template with the correct mapping for alarm command messages.
-curl -XPUT http://${ES_HOST}:${ES_PORT}/_template/alarms_cmd_template -H 'Content-Type: application/json' -d'
+curl -XPUT http://${ES_HOST}:${ES_PORT}/_template/alarms_cmd_template?include_type_name=true -H 'Content-Type: application/json' -d'
 {
   "index_patterns":["*_alarms_cmd*"],
   "mappings" : {  
@@ -129,7 +129,7 @@ curl -XPUT http://${ES_HOST}:${ES_PORT}/_template/alarms_cmd_template -H 'Conten
 '
 
 # Create the elastic template with the correct mapping for alarm config messages.
-curl -XPUT http://${ES_HOST}:${ES_PORT}/_template/alarms_config_template -H 'Content-Type: application/json' -d'
+curl -XPUT http://${ES_HOST}:${ES_PORT}/_template/alarms_config_template?include_type_name=true -H 'Content-Type: application/json' -d'
 {
   "index_patterns":["*_alarms_config*"],
   "mappings" : {  


### PR DESCRIPTION
This post 

https://www.elastic.co/blog/moving-from-types-to-typeless-apis-in-elasticsearch-7-0

explains the necessary change for continuing to use typed mappings when going from ES6 to ES7.
I have not extensively tested this.

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>