### PR TITLE
Remove the xml file as an argument to the alarm logger

### DIFF
--- a/cli/commands/start-alarm-logger
+++ b/cli/commands/start-alarm-logger
@@ -4,7 +4,7 @@
 #
 usage() {
   cli_name=${0##*/}
-  echo "Usage: nalms start-alarm-logger config_name config_file "
+  echo "Usage: nalms start-alarm-logger config_name "
   echo "Requires definition of \$ALARM_LOGGER_PROPERTIES, \$NALMS_DOCKER_ALARM_LOGGER_VERSION and optional definition of"
   echo "\$NALMS_ES_HOST, \$NALMS_ES_PORT, \$NALMS_BOOTSTRAP_SERVERS"
   exit 0
@@ -20,13 +20,6 @@ else
   CONFIG_NAME="$1"
 fi
 
-if [[ -z "$2" ]]; then
-  usage
-else
-  CONFIG_FILE="$2"
-fi
-
-
 if [[ -z "$NALMS_ALARM_LOGGER_PROPERTIES" ]]; then
   echo "Property file not provided."
   usage
@@ -40,12 +33,11 @@ fi
 
 
 if [ "$1" == "-h" ]; then
-  echo "Usage: deploy-configuration.sh [Configuration Name] [Configuration file] [Alarm logger properties file] [Logging configuration files]"
+  echo "Usage: deploy-configuration.sh [Configuration Name] [Alarm logger properties file] [Logging configuration files]"
   exit 0
 fi
 
-docker run -v $CONFIG_FILE:/tmp/nalms/$CONFIG_NAME.xml \
-  -e ES_HOST="${NALMS_ES_HOST}" \
+docker run -e ES_HOST="${NALMS_ES_HOST}" \
   -e ES_PORT="${NALMS_ES_PORT}" \
   -e BOOTSTRAP_SERVERS="${NALMS_KAFKA_BOOTSTRAP}" \
   -e ALARM_LOGGER_PROPERTIES="/opt/nalms/config/alarm_logger.properties" \

--- a/cli/nalms
+++ b/cli/nalms
@@ -12,7 +12,7 @@ NALMS CLI
 Usage: $cli_name [command]
 Commands:
   start-alarm-server config_name config_file
-  start-alarm-logger config_name config_file 
+  start-alarm-logger config_name
   start-alarm-ioc config_name config_file
   start-cruise-control
   start-elasticsearch [--port elasticsearch]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -60,9 +60,9 @@ $ bash cli/nalms list-configurations
 ```
 
 ## start-alarm-logger
-Start the alarm logger for a given configuration name and configuration file. Configuration name must match that defined in the configuration file. This will create an image named `nalms-logger-${CONFIG_NAME}`.
+Start the alarm logger for a given configuration name. This will create an image named `nalms-logger-${CONFIG_NAME}`.
 ```
-$ bash cli/nalms start-alarm-logger config_name config_file
+$ bash cli/nalms start-alarm-logger config_name
 ```
 
 ## start-alarm-server

--- a/phoebus-alarm-logger/cli/commands/start-logger
+++ b/phoebus-alarm-logger/cli/commands/start-logger
@@ -5,7 +5,7 @@
 #
 # Copyright @2021 SLAC National Accelerator Laboratory
 if [ "$1" == "-h" ]; then
-  echo "Usage: start-logger config_name config_file"
+  echo "Usage: start-logger config_name"
   echo "Requires setting \$LOGGING_CONFIG_FILE, \$ALARM_LOGGER_PROPERTIES, \$ALARM_LOGGER_JAR, \$ES_HOST, \$ES_PORT, \$BOOTSTRAP_SERVERS"
   exit 0
 fi
@@ -43,7 +43,6 @@ fi
 
 
 CONFIG_NAME=$1
-CONFIG_FILE=$2
 
 sed 's/$ES_HOST/'"$ES_HOST/" $ALARM_LOGGER_PROPERTIES > /tmp/logger.properties
 sed -i 's/$ES_PORT/'"$ES_PORT/" /tmp/logger.properties


### PR DESCRIPTION
The logger just reads from the kafka queue, it doesn't need to know ahead of time what the structure of the alarm data is unlike the servers