### PR TITLE
Disable ES Sniffer

### DIFF
--- a/phoebus-alarm-logger/Dockerfile
+++ b/phoebus-alarm-logger/Dockerfile
@@ -10,7 +10,7 @@ USER root
 RUN apt-get update && \
     apt-get install -y git maven openjdk-11-jdk && \
     cd /tmp && \
-    git clone https://github.com/ControlSystemStudio/phoebus.git && \
+    git clone https://github.com/jbellister-slac/phoebus.git && \
     cd phoebus && \
     mvn install -pl services/alarm-logger -am -DskipTests && \
     mkdir /opt/phoebus-build && \


### PR DESCRIPTION
Switches to the phoebus fork for the logger too in order to disable the auto-configured spring boot elasticsearch sniffer.

Error that will be eliminated due to sniffer running against non-existing localhost ES cluster:

```
org.elasticsearch.client.sniff.Sniffer$Task run
SEVERE: error while sniffing nodes
java.net.ConnectException: Connection refused
        at org.elasticsearch.client.RestClient.extractAndWrapCause(RestClient.java:918)
        at org.elasticsearch.client.RestClient.performRequest(RestClient.java:299)
        at org.elasticsearch.client.RestClient.performRequest(RestClient.java:287)
        at org.elasticsearch.client.sniff.ElasticsearchNodesSniffer.sniff(ElasticsearchNodesSniffer.java:106)
        at org.elasticsearch.client.sniff.Sniffer.sniff(Sniffer.java:209)
        at org.elasticsearch.client.sniff.Sniffer$Task.run(Sniffer.java:140)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.net.ConnectException: Connection refused
        at java.base/sun.nio.ch.SocketChannelImpl.checkConnect(Native Method)
        at java.base/sun.nio.ch.SocketChannelImpl.finishConnect(SocketChannelImpl.java:777)
        at org.apache.http.impl.nio.reactor.DefaultConnectingIOReactor.processEvent(DefaultConnectingIOReactor.java:174)
        at org.apache.http.impl.nio.reactor.DefaultConnectingIOReactor.processEvents(DefaultConnectingIOReactor.java:148)
        at org.apache.http.impl.nio.reactor.AbstractMultiworkerIOReactor.execute(AbstractMultiworkerIOReactor.java:351)
        at org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager.execute(PoolingNHttpClientConnectionManager.java:221)
        at org.apache.http.impl.nio.client.CloseableHttpAsyncClientBase$1.run(CloseableHttpAsyncClientBase.java:64)
        ... 1 more
```

Spring boot info:

https://docs.spring.io/spring-boot/docs/3.0.1/reference/html/data.html#data.nosql.elasticsearch.connecting-using-rest.restclient

https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html#application-properties.core.spring.autoconfigure.exclude

Why we don't need sniffing (Kubernetes handles the load balancing for us):

https://www.elastic.co/blog/elasticsearch-sniffing-best-practices-what-when-why-how