### PR TITLE
Update alarm server and logger

### DIFF
--- a/phoebus-alarm-logger/Dockerfile
+++ b/phoebus-alarm-logger/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:latest as build
+FROM debian:bullseye-slim as build
 
 ENV JAVA_BASE java-11-openjdk
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
@@ -19,7 +19,7 @@ RUN apt-get update && \
     apt-get remove -y openjdk-11-jdk maven git
 
 
-FROM debian:latest as runtime
+FROM debian:bullseye-slim as build
 
 COPY logging.properties /opt/nalms/config/logging.properties
 COPY cli /opt/nalms/cli

--- a/phoebus-alarm-logger/cli/cli
+++ b/phoebus-alarm-logger/cli/cli
@@ -18,7 +18,7 @@ Commands:
 
 case "$1" in
   start-logger|d)
-    . "$CLI_WORKDIR/commands/start-logger" "$2" "$3" | tee -ia "$CLI_WORKDIR/start-logger_${2}.log"
+    . "$CLI_WORKDIR/commands/start-logger" "$2" | tee -ia "$CLI_WORKDIR/start-logger_${2}.log"
     ;;
   *)
     cli_help

--- a/phoebus-alarm-server/Dockerfile
+++ b/phoebus-alarm-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:latest as build
+FROM debian:bullseye-slim as build
 
 ENV JAVA_BASE java-11-openjdk
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
@@ -20,7 +20,7 @@ RUN apt-get update && \
     apt-get remove -y openjdk-11-jdk maven git
 
 
-FROM debian:latest as runtime
+FROM debian:bullseye-slim as build
 
 COPY cli /opt/nalms/cli
 COPY requirements.txt /opt/nalms/requirements.txt
@@ -38,7 +38,7 @@ ENV BUNDLED_KAFKA_VERSION 2.13-3.3.2
 
 # general
 RUN apt-get update && \
-    apt-get install -y openjdk-11-jre curl iputils-ping wget python3-pip && \
+    apt-get install -y openjdk-11-jre curl iputils-ping wget python3-pip nano && \
     mkdir /tmp/nalms && \
     mkdir /opt/phoebus && \
     chmod +x /opt/nalms/cli/cli &&\

--- a/phoebus-alarm-server/Dockerfile
+++ b/phoebus-alarm-server/Dockerfile
@@ -38,7 +38,7 @@ ENV BUNDLED_KAFKA_VERSION 2.13-3.3.2
 
 # general
 RUN apt-get update && \
-    apt-get install -y openjdk-11-jre curl iputils-ping wget python3-pip nano && \
+    apt-get install -y openjdk-11-jre curl iputils-ping wget python3-pip && \
     mkdir /tmp/nalms && \
     mkdir /opt/phoebus && \
     chmod +x /opt/nalms/cli/cli &&\

--- a/phoebus-alarm-server/cli/commands/start-server
+++ b/phoebus-alarm-server/cli/commands/start-server
@@ -49,7 +49,7 @@ fi
 
 if java -jar $ALARM_SERVER_JAR -settings /tmp/alarm_server.properties -config $CONFIG_NAME -import $CONFIG_FILE; then
 
-  java -jar $ALARM_SERVER_JAR -config $CONFIG_NAME -settings /tmp/alarm_server.properties -noshell -logging $LOGGING_CONFIG_FILE
+  java -jar $ALARM_SERVER_JAR -config $CONFIG_NAME -settings /tmp/alarm_server.properties -noshell -logging $LOGGING_CONFIG_FILE -xml_file $CONFIG_FILE
 
 else
     echo "Unable to import configuration."


### PR DESCRIPTION
Uses the slim build of the current version of debian for both. Fixes an unneeded reference to the alarm xml config file in the logger that was missed in #109. Adds an argument when starting up the server to point to the file path of the xml config that can be reloaded while the application is running.