### PR TITLE
ENH: Stop skipping duplicate PV names

### DIFF
--- a/nalms-tools/nalms_tools/alh_conversion.py
+++ b/nalms-tools/nalms_tools/alh_conversion.py
@@ -107,11 +107,7 @@ class AlarmNode:
             child (str): Name of the child node 
 
         """
-        if child in self.node_children:
-            logger.warning(f"DUPLICATE CHILD FOR GROUP {self.name}: {child}")
-
-        else:
-            self.node_children.append(child)
+        self.node_children.append(child)
 
     def remove_child(self, child: str) -> None:
         """ Remove a child from the node. 


### PR DESCRIPTION
PVs can appear as part of multiple paths along the tree now, so no need to skip