### PR TITLE
ENH: Add the option to log out messages from kafka that will get picked up by promtail -> loki

### DIFF
--- a/loki-alarm-logger/Dockerfile
+++ b/loki-alarm-logger/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.17
+
+RUN apk add --no-cache bash tzdata python3 py3-pip
+
+ENV TZ=America/Los_Angeles
+
+RUN pip3 install kafka-python
+
+COPY alarm_logger.py /alarm_logger.py
+
+ENTRYPOINT ["python3", "/alarm_logger.py"]

--- a/loki-alarm-logger/alarm_logger.py
+++ b/loki-alarm-logger/alarm_logger.py
@@ -1,0 +1,76 @@
+import argparse
+import json
+import logging
+from datetime import datetime
+from kafka import KafkaConsumer
+from kafka.consumer.fetcher import ConsumerRecord
+from typing import List
+
+
+logging.basicConfig(level=logging.INFO, format='%(message)s')
+
+
+class AlarmLogger():
+    """
+    AlarmLogger is a simple class for reading message from kafka topics and logging them out to be
+    processed by promtail -> loki.
+
+    Parameters
+    ----------
+    topics : List[str]
+        A list of topics representing the alarm configs to listen to
+    bootstrap_servers : List[str]
+        A list containing one or more urls for kafka bootstrap servers
+    """
+
+    def __init__(self, topics: List[str], bootstrap_servers: List[str]):
+        self.topics = topics
+        self.current_alarms = dict()
+        self.main_consumer = KafkaConsumer(*topics,
+                                           bootstrap_servers=bootstrap_servers,
+                                           auto_offset_reset='latest',
+                                           enable_auto_commit=False,
+                                           key_deserializer=lambda x: x.decode('utf-8'),
+                                           value_deserializer=self.value_decode)
+
+
+    def value_decode(self, x):
+        if x is not None:
+            return json.loads(x.decode('utf-8'))
+        return None
+
+    def run(self):
+        for message in self.main_consumer:
+            if len(message.value) > 1:
+                message.value['path'] = message.key
+                message.value['pv_name'] = message.key.split('/')[-1]
+                message.value['topic_name'] = message.key.split('/')[1]
+                if 'severity' in message.value:
+                    # This is likely a duplicate message from kafka, no need to log again
+                    if self.current_alarms.get(message.key) == message.value['severity']:
+                        continue
+                    self.current_alarms[message.key] = message.value['severity']
+                if 'time' in message.value:
+                    message.value['time'] = str(datetime.fromtimestamp(message.value['time']['seconds']))
+                logging.info(f'{message.value}')
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Alarm Logger")
+    parser.add_argument('--topics', help='Comma separated list of kafka alarm topics to listen to')
+    parser.add_argument('--bootstrap-servers',
+                        default='localhost:9092',
+                        help='Comma separated list of urls for one or more kafka boostrap servers')
+
+
+    app_args = parser.parse_args()
+    topics = app_args.topics.split(',')
+    kafka_boostrap_servers = app_args.bootstrap_servers.split(',')
+    
+
+    kafka_consumer = AlarmLogger(topics, kafka_boostrap_servers)
+    kafka_consumer.run()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This just reads and logs messages read from kafka, under the assumption that there is something running (promtail in our case) that will grab the logs and push to a long term storage solution (loki).

Note this could likely all be done directly with promtail, and I may look into that instead