### PR TITLE
fix server startup

### DIFF
--- a/phoebus-alarm-server/cli/commands/start-server
+++ b/phoebus-alarm-server/cli/commands/start-server
@@ -47,10 +47,8 @@ if [[ "$ALARM_IOC" = true ]]; then
   python3 /opt/nalms/scripts/update_ioc.py $CONFIG_NAME $KAFKA_BOOTSTRAP &
 fi
 
-if java -jar $ALARM_SERVER_JAR -settings /tmp/alarm_server.properties -config $CONFIG_NAME -import $CONFIG_FILE; then
-
-  java -jar $ALARM_SERVER_JAR -config $CONFIG_NAME -settings /tmp/alarm_server.properties -noshell -logging $LOGGING_CONFIG_FILE -xml_file $CONFIG_FILE
-
+if java -jar $ALARM_SERVER_JAR -config $CONFIG_NAME -settings /tmp/alarm_server.properties -noshell -logging $LOGGING_CONFIG_FILE -import $CONFIG_FILE; then
+    :
 else
     echo "Unable to import configuration."
 fi


### PR DESCRIPTION
clarify phoebus alarm server startup.

ensure that logging configuration is properly handled

insert a noop into the if branch instead a nonsensical extraneous command. note that `-xml_file` is not a recognized argument and never was. 