### PR TITLE
fix logging for alarm-logger

### DIFF
--- a/phoebus-alarm-logger/cli/commands/start-logger
+++ b/phoebus-alarm-logger/cli/commands/start-logger
@@ -49,4 +49,4 @@ sed -i 's/$ES_PORT/'"$ES_PORT/" /tmp/logger.properties
 sed -i 's/$BOOTSTRAP_SERVERS/'"$BOOTSTRAP_SERVERS/" /tmp/logger.properties
 
 
-java -jar $ALARM_LOGGER_JAR -properties /tmp/logger.properties -topics $CONFIG_NAME -noshell
+java -jar $ALARM_LOGGER_JAR -properties /tmp/logger.properties -logging $LOGGING_CONFIG_FILE -topics $CONFIG_NAME -noshell

--- a/phoebus-alarm-logger/logging.properties
+++ b/phoebus-alarm-logger/logging.properties
@@ -1,14 +1,14 @@
-# Default java.util.logging configuration for alarm server
+# Default java.util.logging configuration for alarm logger
 #
-# Read in AlarmServerMain via LogManager
+# Read in AlarmLoggingService via LogManager
 
 handlers = java.util.logging.ConsoleHandler
 
 # Levels: SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST, ALL
 # General level 'FINE' to enable logging, which is then fine-tuned below
-.level = FINE
+.level = INFO
 
-java.util.logging.ConsoleHandler.level = ALL
+java.util.logging.ConsoleHandler.level = INFO
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 # 1: date, 2: source, 3: logger, 4: level, 5: message, 6:thrown
 # Adding the logger name [%3$s] can be useful to determine which logger to _disable_,
@@ -20,10 +20,7 @@ java.util.logging.SimpleFormatter.format=%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$
 
 
 # Throttle messages for certain packages
-# Raise back up from 'WARNING' to debug
-javax.activation.level = WARNING
-javax.mail.level = WARNING
-com.sun.mail.smtp.level = WARNING
-
+org.phoebus.alarm.logging.level = INFO
+org.elasticsearch.client.RestClient.level = WARNING
+org.apache.catalina.core.StandardService.level = WARNING
 org.apache.kafka.level = WARNING
-org.phoebus.applications.alarm.level = INFO


### PR DESCRIPTION
the logging.properties have no effect unless specified on the commandline via the `-logging` argument

the current logging.properties were apparently copied from the alarm-server logging.properties. the alarm-logger logging.properties should be different, though. for example there is  `org.elasticsearch.client.RestClient.level` for the alarm logger, which would be meaningless for the alarm server


this brings the nalms deployment in line with the phoebus repository

```
phoebus.git [master|✔]$ diff services/alarm-logger/src/main/resources/alarm_logger_logging.properties  services/alarm-server/src/main/resources/alarm_server_logging.properties 
1c1
< # Default java.util.logging configuration for alarm logger
---
> # Default java.util.logging configuration for alarm server
3c3
< # Read in AlarmLoggingService via LogManager
---
> # Read in AlarmServerMain via LogManager
9c9
< .level = INFO
---
> .level = FINE
11c11
< java.util.logging.ConsoleHandler.level = INFO
---
> java.util.logging.ConsoleHandler.level = ALL
23,25c23,27
< org.phoebus.alarm.logging.level = INFO
< org.elasticsearch.client.RestClient.level = WARNING
< org.apache.catalina.core.StandardService.level = WARNING
---
> # Raise back up from 'WARNING' to debug
> javax.activation.level = WARNING
> javax.mail.level = WARNING
> com.sun.mail.smtp.level = WARNING
> 
26a29,33
> 
> org.phoebus.applications.alarm.level = INFO
> com.cosylab.epics.caj.level = WARNING
> org.phoebus.framework.rdb.level = WARNING
> org.phoebus.pv.level = WARNING
```