### PR TITLE
Update alarm server so that alarm acknowledgments and bypasses persist through alarm server reboots

### DIFF
--- a/phoebus-alarm-server/Dockerfile
+++ b/phoebus-alarm-server/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
     git clone https://github.com/jbellister-slac/phoebus.git && \
     cd phoebus && \
     git fetch --tags && \
-    git checkout tags/v4.7.2-1.0.0 && \
+    git checkout tags/v4.7.2-1.1.0 && \
     mvn install -pl services/alarm-server -am -DskipTests && \
     mkdir /opt/phoebus-build && \
     mv /opt/phoebus/services/alarm-server/target/service-alarm-server-*.jar /opt/phoebus-build/service-alarm-server.jar && \


### PR DESCRIPTION
Changes have already been pushed upstream to phoebus, so this will be the default when a new version of that is released.

https://github.com/jbellister-slac/phoebus/commit/f339004000a2c2d18fcbe1f1ea6c9a6e4872f9f8
